### PR TITLE
#14 extract interface from BotSimple

### DIFF
--- a/src/main/java/com/g4s8/teletakes/bot/Bot.java
+++ b/src/main/java/com/g4s8/teletakes/bot/Bot.java
@@ -1,0 +1,72 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2018 g4s8
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.g4s8.teletakes.bot;
+
+import java.io.IOException;
+import org.telegram.telegrambots.api.methods.send.SendMessage;
+
+/**
+ * Bot.
+ * @since 1.0
+ */
+public interface Bot {
+
+    /**
+     * Ctor.
+     * @param msg Message to send
+     * @throws IOException When smth went wrong
+     */
+    void send(SendMessage msg) throws IOException;
+
+    /**
+     * Fake implementation of {@link Bot}.
+     */
+    final class Fake implements Bot {
+
+        /**
+         * Was message sent?
+         */
+        private boolean sent;
+
+        /**
+         * Ctor.
+         */
+        public Fake() {
+            this.sent = false;
+        }
+
+        @Override
+        public void send(final SendMessage msg) {
+            this.sent = true;
+        }
+
+        /**
+         * Was message sent?
+         * @return True if was false otherwise
+         */
+        public boolean sent() {
+            return this.sent;
+        }
+    }
+}

--- a/src/main/java/com/g4s8/teletakes/bot/BotSimple.java
+++ b/src/main/java/com/g4s8/teletakes/bot/BotSimple.java
@@ -48,6 +48,7 @@ import org.telegram.telegrambots.api.objects.replykeyboard.buttons.InlineKeyboar
 import org.telegram.telegrambots.api.objects.replykeyboard.buttons.KeyboardButton;
 import org.telegram.telegrambots.api.objects.replykeyboard.buttons.KeyboardRow;
 import org.telegram.telegrambots.bots.TelegramLongPollingBot;
+import org.telegram.telegrambots.exceptions.TelegramApiException;
 
 /**
  * Simple bot.
@@ -56,7 +57,7 @@ import org.telegram.telegrambots.bots.TelegramLongPollingBot;
  * @todo #1:30min Refactor this class and split into few smaller,
  *  also remove all checkstyle and PMD suppressions.
  */
-public final class BotSimple extends TelegramLongPollingBot {
+public final class BotSimple extends TelegramLongPollingBot implements Bot {
 
     /**
      * Take.
@@ -92,6 +93,15 @@ public final class BotSimple extends TelegramLongPollingBot {
         this.name = name;
         this.token = token;
         this.threads = Executors.newCachedThreadPool();
+    }
+
+    @Override
+    public void send(final SendMessage msg) throws IOException {
+        try {
+            this.execute(msg);
+        } catch (final TelegramApiException ex) {
+            throw new IOException("Failed to send message", ex);
+        }
     }
 
     @Override


### PR DESCRIPTION
For #14 I've extracted simple interface that can send messages from `BotSimple`, created corresponding method in `BotSimple` and `Fake` implementation. I believe this simple improvement will help us a lot with tests for classes depending on `BotSimple`. For example `TkNotifications.java` in harvest telegram and new notification classes developed in ghman https://github.com/g4s8/ghman/pull/26.